### PR TITLE
 #167827218 add reject mentorship session request api

### DIFF
--- a/server/controllers/session_controller.js
+++ b/server/controllers/session_controller.js
@@ -33,5 +33,14 @@ class SessionController {
     const result = Session.accept(res, req.params.id);
     return res.status(200).send({ status: 200, data: { data: result } });
   }
+
+  // reject sessions
+  rejectSession = (req, res) => {
+    if (isNaN(req.params.id.trim())) {
+      return res.status(status.BAD_REQUEST).send({ status: status.BAD_REQUEST, error: 'Session id should be an integer' });
+    }
+    const result = Session.reject(res, req.params.id);
+    return res.status(200).send({ status: 200, data: { data: result } });
+  }
 }
 export default SessionController;

--- a/server/models/session_model.js
+++ b/server/models/session_model.js
@@ -53,8 +53,34 @@ class Session {
         error: 'This session is already accepted',
       });
     }
+    if (session.status === 'Reject') {
+      return res.status(status.FORBIDDEN).send({
+        status: status.FORBIDDEN,
+        error: 'This session is already rejected',
+      });
+    }
 
     session.status = 'Accept';
+    return session;
+  }
+
+  // reject sessions
+  reject = (res, id) => {
+    const session = this.sessions.find((sid) => sid.sessionId === parseInt(id, 10));
+    if (!session) return res.status(404).send({ status: 404, error: 'this session  is not found!' });
+    if (session.status === 'Accept') {
+      return res.status(status.FORBIDDEN).send({
+        status: status.FORBIDDEN,
+        error: 'This session is already accepted',
+      });
+    }
+    if (session.status === 'Reject') {
+      return res.status(status.FORBIDDEN).send({
+        status: status.FORBIDDEN,
+        error: 'This session is already rejected',
+      });
+    }
+    session.status = 'Reject';
     return session;
   }
 }

--- a/server/routes/session_route.js
+++ b/server/routes/session_route.js
@@ -13,6 +13,8 @@ const session_controller = new SessionController();
 router.post('/sessions', auth, session_controller.create);
 // accept sessions
 router.patch('/sessions/:id/accept', mentor, session_controller.acceptSession);
+// reject session
+router.patch('/sessions/:id/reject', mentor, session_controller.rejectSession);
 
 
 export default router;

--- a/server/test/session-test.js
+++ b/server/test/session-test.js
@@ -227,3 +227,109 @@ describe('38 . PATCH mentor can accept session ehen session is not integer', () 
       });
   });
 });
+
+describe('39 . PATCH mentor can reject session', () => {
+  beforeEach((done) => {
+    chai.request(app).post('/api/v1/auth/signin').send({ email: 'chance@gmail.com', password: 'iradukunda' }).then((res) => {
+      mentorToken = res.body.data.token;
+      // console.log(res.body.data.token);
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return session data ', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/1/reject')
+      .set('x-auth-token', mentorToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(status.REQUEST_SUCCEEDED);
+        expect(res.body.status).to.equal(status.REQUEST_SUCCEEDED);
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+});
+
+describe('40 . PATCH mentor can reject session ehen session is already accepted', () => {
+  beforeEach((done) => {
+    chai.request(app).post('/api/v1/auth/signin').send({ email: 'chance@gmail.com', password: 'iradukunda' }).then((res) => {
+      mentorToken = res.body.data.token;
+      // console.log(res.body.data.token);
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return already accepted ', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/2/reject')
+      .set('x-auth-token', mentorToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(status.FORBIDDEN);
+        expect(res.body.status).to.equal(status.FORBIDDEN);
+        expect(res.body.error).to.equal('This session is already accepted');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+});
+describe('41 . PATCH mentor can reject session ehen session is not found', () => {
+  beforeEach((done) => {
+    chai.request(app).post('/api/v1/auth/signin').send({ email: 'chance@gmail.com', password: 'iradukunda' }).then((res) => {
+      mentorToken = res.body.data.token;
+      // console.log(res.body.data.token);
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return session id is not found ', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/9/reject')
+      .set('x-auth-token', mentorToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(status.NOT_FOUND);
+        expect(res.body.status).to.equal(status.NOT_FOUND);
+        expect(res.body.error).to.equal('this session  is not found!');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+});
+
+describe('42 . PATCH mentor can reject session ehen session is not integer', () => {
+  beforeEach((done) => {
+    chai.request(app).post('/api/v1/auth/signin').send({ email: 'chance@gmail.com', password: 'iradukunda' }).then((res) => {
+      mentorToken = res.body.data.token;
+      // console.log(res.body.data.token);
+      done();
+    })
+      .catch((err) => console.log(err));
+  });
+  it('should return session id is not integer ', (done) => {
+    chai.request(app)
+      .patch('/api/v1/sessions/q/reject')
+      .set('x-auth-token', mentorToken)
+      .set('Accept', 'application/json')
+      .then((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(status.BAD_REQUEST);
+        expect(res.body.status).to.equal(status.BAD_REQUEST);
+        expect(res.body.error).to.equal('Session id should be an integer');
+        done();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+});


### PR DESCRIPTION
## What this PR does
- add its route
- add its test
- add its code in session controller
- add its code in session_model
## Description of a task
* A mentor should be able to reject a mentorship session request using ' /api/v1/sessions/2/reject'
## Link to the PT story
* [A mentor should be able to reject a mentorship session request](https://www.pivotaltracker.com/story/show/167827218)
## How to test this manually 
* clone repo
* run code
## Screenshots
* N/A
