### PR TITLE
#168436563 add accept and reject session request api

### DIFF
--- a/server/controllers/session_controller.js
+++ b/server/controllers/session_controller.js
@@ -2,8 +2,9 @@ import dotenv from 'dotenv';
 import status from '../helpers/StatusCode';
 import Model from '../models/queries';
 import { userId, userEmail } from '../helpers/userData';
-import notNumber from '../helpers/notNumber';
 import { notFound, conflict, serverError } from '../helpers/response';
+import notNumber from '../helpers/notNumber';
+
 
 dotenv.config();
 class SessionController {

--- a/server/helpers/response.js
+++ b/server/helpers/response.js
@@ -1,0 +1,15 @@
+import status from './StatusCode';
+
+export const notFound = (id, res) => res.status(status.NOT_FOUND).send({
+  status: status.NOT_FOUND,
+  error: `Session with id ${id} does not exist`,
+});
+export const conflict = (id, res) => res.status(status.REQUEST_CONFLICT).send({
+  status: status.REQUEST_CONFLICT,
+  error: `Session with id ${id} is already accepted`,
+});
+
+export const serverError = (err, res) => res.status(status.SERVER_ERROR).send({
+  status: status.SERVER_ERROR,
+  error: err,
+});

--- a/server/middleware/mentor.js
+++ b/server/middleware/mentor.js
@@ -1,0 +1,23 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+import status from '../helpers/StatusCode';
+
+dotenv.config();
+
+const mentor = (req, res, next) => {
+  const token = req.header('x-auth-token');
+  try {
+    const decoded_jwt = jwt.verify(token, 'process.env.SECRETEKEY');
+
+    if (!decoded_jwt.is_mentor) {
+      return res.status(status.FORBIDDEN).send({ status: status.FORBIDDEN, error: 'You are not authorized to perform this action.' });
+    }
+    next();
+  } catch (error) {
+    return res.status(status.BAD_REQUEST).send(
+      { status: status.BAD_REQUEST, error: error.message },
+    );
+  }
+};
+
+export default mentor;

--- a/server/models/testQueries.js
+++ b/server/models/testQueries.js
@@ -39,7 +39,7 @@ INSERT INTO users (
 DROP TABLE IF EXISTS sessions CASCADE;
 CREATE TABLE sessions(
   session_id SERIAL NOT NULL PRIMARY KEY,
-  mentorId INTEGER NOT NULL,
+  mentor_id INTEGER NOT NULL,
   questions VARCHAR NOT NULL,
   mentee_id INTEGER NOT NULL,
   mentee_email VARCHAR NOT NULL,

--- a/server/routes/session_route.js
+++ b/server/routes/session_route.js
@@ -9,10 +9,10 @@ dotenv.config();
 
 const router = express.Router();
 
-const { createSession, AcceptSession, rejectSession } = SessionController;
+const { createSession, acceptSession, rejectSession } = SessionController;
 
 router.post('/sessions', sessionValidator, auth.auth, createSession);
-router.patch('/sessions/:id/accept', mentor, AcceptSession);
+router.patch('/sessions/:id/accept', mentor, acceptSession);
 router.patch('/sessions/:id/reject', mentor, rejectSession);
 
 export default router;

--- a/server/routes/session_route.js
+++ b/server/routes/session_route.js
@@ -3,13 +3,16 @@ import dotenv from 'dotenv';
 import SessionController from '../controllers/session_controller';
 import sessionValidator from '../middleware/sessionsValidator';
 import auth from '../middleware/auth';
+import mentor from '../middleware/mentor';
 
 dotenv.config();
 
 const router = express.Router();
 
-const { createSession } = SessionController;
+const { createSession, AcceptSession, rejectSession } = SessionController;
 
 router.post('/sessions', sessionValidator, auth.auth, createSession);
+router.patch('/sessions/:id/accept', mentor, AcceptSession);
+router.patch('/sessions/:id/reject', mentor, rejectSession);
 
 export default router;


### PR DESCRIPTION
## What this PR does
- add accept mentorship session api  
-  add accept mentorship session api 
## Description of the task to be completed
* A mentor should be able to reject a mentorship session request
* A mentor should be able to accept a mentorship session request


### How should this be manually tested?
* Clone the app
* use 'npm install' to install all necessary dependencies
* Run 'npm start' to make the server run
* use Postman and run 
- ```localhost:4000/api/v2/sessions/:sessionId/reject``` 
- ```localhost:4000/api/v2/sessions/:sessionId/accept```
## Any background context you want to provide?
* N/A
## Link to Pivot tracker stories
* [Accept mentorship session request](https://www.pivotaltracker.com/story/show/168436429)
* [Reject mentorship session request](https://www.pivotaltracker.com/story/show/168436563)
## Screenshots
![accept](https://user-images.githubusercontent.com/38111965/64725529-0e9fff80-d4d5-11e9-9bd7-5a235ddc1186.PNG)
![reject](https://user-images.githubusercontent.com/38111965/64725549-19f32b00-d4d5-11e9-9c06-e93856cde704.PNG)


